### PR TITLE
Add finger width field and patches from VoodooPS2

### DIFF
--- a/VoodooInput/VoodooInput.cpp
+++ b/VoodooInput/VoodooInput.cpp
@@ -15,6 +15,7 @@ void VoodooInput::free() {
 
 bool VoodooInput::start(IOService *provider) {
     if (!super::start(provider)) {
+        IOLog("Kishor VoodooInput could not super::start!\n");
         return false;
     }
     
@@ -32,6 +33,7 @@ bool VoodooInput::start(IOService *provider) {
     
     if (!transformNumber || !logicalMaxXNumber || !logicalMaxYNumber
             || !physicalMaxXNumber || !physicalMaxYNumber) {
+        IOLog("Kishor VoodooInput could not get provider properties!\n");
         return false;
     }
     
@@ -46,23 +48,30 @@ bool VoodooInput::start(IOService *provider) {
     actuator = OSTypeAlloc(VoodooInputActuatorDevice);
     
     if (!simulator || !actuator) {
+        IOLog("Kishor VoodooInput could not alloc simulator or actuator!\n");
         OSSafeReleaseNULL(simulator);
         OSSafeReleaseNULL(actuator);
         return false;
     }
     
     // Initialize simulator device
-    if (!simulator->init(NULL) || !simulator->attach(this))
+    if (!simulator->init(NULL) || !simulator->attach(this)) {
+        IOLog("Kishor VoodooInput could not attach simulator!\n");
         goto exit;
+    }
     else if (!simulator->start(this)) {
+        IOLog("Kishor VoodooInput could not start simulator!\n");
         simulator->detach(this);
         goto exit;
     }
     
     // Initialize actuator device
-    if (!actuator->init(NULL) || !actuator->attach(this))
+    if (!actuator->init(NULL) || !actuator->attach(this)) {
+        IOLog("Kishor VoodooInput could not init or attach actuator!\n");
         goto exit;
+    }
     else if (!actuator->start(this)) {
+        IOLog("Kishor VoodooInput could not start actuator!\n");
         actuator->detach(this);
         goto exit;
     }

--- a/VoodooInput/VoodooInputMultitouch/VoodooInputTransducer.h
+++ b/VoodooInput/VoodooInputMultitouch/VoodooInputTransducer.h
@@ -17,7 +17,8 @@ enum VoodooInputTransducerType {
 struct TouchCoordinates {
     UInt32 x;
     UInt32 y;
-    UInt32 pressure;
+    UInt8 pressure;
+    UInt8 width;
 };
 
 struct VoodooInputTransducer {


### PR DESCRIPTION
1. Change physical dimensions to 0.01 mm units, as used by MT2 HID report
2. Report physical dimensions in both places of HID report
3. Add width field instead of `new_touch_state` hack (if VoodooI2C needs it, it should be implemented there. VoodooPS2 reports pressure as width)
4. Pass pressure to the system as is (for Force Touch emulation) – the caller needs to set it to appropriate values
5. Add error logging to see what is preventing the kext to start