### PR TITLE
Fix race condition / loading failures happening on specific devices

### DIFF
--- a/VoodooInput/Info.plist
+++ b/VoodooInput/Info.plist
@@ -50,5 +50,7 @@
 		<key>com.apple.kpi.mach</key>
 		<string>13.0</string>
 	</dict>
+	<key>OSBundleRequired</key>
+	<string>Root</string>
 </dict>
 </plist>


### PR DESCRIPTION
The #5 and [#600](https://github.com/acidanthera/bugtracker/issues/600) seems to be a race condition issue, kext fails to load, pretty much same scenario we had with VoodooI2C.kext.

Before the change, it didn't work even once for me on my Lenovo ThinkPad X240, after i made the change, i rebooted like 20x and the touchpad is working perfect on every boot.

Cheers !