### PR TITLE
Use C++ style structs, remove free() method

### DIFF
--- a/VoodooInput/VoodooInput.cpp
+++ b/VoodooInput/VoodooInput.cpp
@@ -6,13 +6,6 @@
 #define super IOService
 OSDefineMetaClassAndStructors(VoodooInput, IOService);
 
-void VoodooInput::free() {
-    OSSafeReleaseNULL(simulator);
-    OSSafeReleaseNULL(actuator);
-    
-    super::free();
-}
-
 bool VoodooInput::start(IOService *provider) {
     if (!super::start(provider)) {
         IOLog("Kishor VoodooInput could not super::start!\n");
@@ -93,11 +86,13 @@ void VoodooInput::stop(IOService *provider) {
     if (simulator) {
         simulator->stop(this);
         simulator->detach(this);
+        OSSafeReleaseNULL(simulator);
     }
     
     if (actuator) {
         actuator->stop(this);
         actuator->detach(this);
+        OSSafeReleaseNULL(actuator);
     }
     
     if (parentProvider->isOpen(this)) {

--- a/VoodooInput/VoodooInput.hpp
+++ b/VoodooInput/VoodooInput.hpp
@@ -25,8 +25,6 @@ class EXPORT VoodooInput : public IOService {
     UInt32 physicalMaxX = 0;
     UInt32 physicalMaxY = 0;
 public:
-    void free() override;
-
     bool start(IOService* provider) override;
     void stop(IOService* provider) override;
     

--- a/VoodooInput/VoodooInputMultitouch/VoodooInputEvent.h
+++ b/VoodooInput/VoodooInputMultitouch/VoodooInputEvent.h
@@ -9,17 +9,17 @@
 
 #include "VoodooInputTransducer.h"
 
-typedef struct {
+struct VoodooInputEvent {
     UInt8 contact_count;
     AbsoluteTime timestamp;
     VoodooInputTransducer transducers[VOODOO_INPUT_MAX_TRANSDUCERS];
-} VoodooInputEvent;
+};
 
-typedef struct {
+struct VoodooInputDimensions {
     SInt32 min_x;
     SInt32 max_x;
     SInt32 min_y;
     SInt32 max_y;
-} VoodooInputDimensions;
+};
 
 #endif /* VoodooInputEvent_h */


### PR DESCRIPTION
`free` should be parallel to `init`, i.e. only free whatever was allocated in `init`.
Moved releases to `stop` method, which is parallel to `start` (Simulator/Actuator are allocated there).

`typedef` is really unnecessary for C++ structs 😉