### PR TITLE
Re-add pressure spoofing to support devices that do not support widths or pressure

### DIFF
--- a/VoodooInput/VoodooInput.cpp
+++ b/VoodooInput/VoodooInput.cpp
@@ -26,7 +26,7 @@ bool VoodooInput::start(IOService *provider) {
     
     if (transformNumber == nullptr || logicalMaxXNumber == nullptr || logicalMaxYNumber == nullptr ||
 		physicalMaxXNumber == nullptr || physicalMaxYNumber == nullptr) {
-        IOLog("Kishor VoodooInput could not get provider properties!\n");
+        IOLog("VoodooInput could not get provider properties!\n");
         return false;
     }
     
@@ -41,7 +41,7 @@ bool VoodooInput::start(IOService *provider) {
     actuator = OSTypeAlloc(VoodooInputActuatorDevice);
     
     if (!simulator || !actuator) {
-        IOLog("Kishor VoodooInput could not alloc simulator or actuator!\n");
+        IOLog("VoodooInput could not alloc simulator or actuator!\n");
         OSSafeReleaseNULL(simulator);
         OSSafeReleaseNULL(actuator);
         return false;
@@ -49,22 +49,22 @@ bool VoodooInput::start(IOService *provider) {
     
     // Initialize simulator device
     if (!simulator->init(NULL) || !simulator->attach(this)) {
-        IOLog("Kishor VoodooInput could not attach simulator!\n");
+        IOLog("VoodooInput could not attach simulator!\n");
         goto exit;
     }
     else if (!simulator->start(this)) {
-        IOLog("Kishor VoodooInput could not start simulator!\n");
+        IOLog("VoodooInput could not start simulator!\n");
         simulator->detach(this);
         goto exit;
     }
     
     // Initialize actuator device
     if (!actuator->init(NULL) || !actuator->attach(this)) {
-        IOLog("Kishor VoodooInput could not init or attach actuator!\n");
+        IOLog("VoodooInput could not init or attach actuator!\n");
         goto exit;
     }
     else if (!actuator->start(this)) {
-        IOLog("Kishor VoodooInput could not start actuator!\n");
+        IOLog("VoodooInput could not start actuator!\n");
         actuator->detach(this);
         goto exit;
     }
@@ -72,7 +72,7 @@ bool VoodooInput::start(IOService *provider) {
     setProperty(VOODOO_INPUT_IDENTIFIER, kOSBooleanTrue);
     
     if (!parentProvider->open(this)) {
-        IOLog("Kishor VoodooInput could not open!\n");
+        IOLog("VoodooInput could not open!\n");
         return false;
     };
     

--- a/VoodooInput/VoodooInputMultitouch/VoodooInputTransducer.h
+++ b/VoodooInput/VoodooInputMultitouch/VoodooInputTransducer.h
@@ -31,6 +31,7 @@ struct VoodooInputTransducer {
     bool isValid;
     bool isPhysicalButtonDown;
     bool isTransducerActive;
+    bool supportsPressure;
     
     TouchCoordinates currentCoordinates;
     TouchCoordinates previousCoordinates;

--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
@@ -35,6 +35,8 @@ void VoodooInputSimulatorDevice::constructReportGated(const VoodooInputEvent& mu
     if (!ready_for_reports)
         return;
     
+    IOLog("VoodooInput got input, count: %d\n", multitouch_event.contact_count);
+    
     AbsoluteTime timestamp = multitouch_event.timestamp;
 
     input_report.ReportID = 0x02;
@@ -170,10 +172,41 @@ void VoodooInputSimulatorDevice::constructReportGated(const VoodooInputEvent& mu
         }
         newunknown = first_unknownbit - (4 * i);
 
-        finger_data.Pressure = transducer->currentCoordinates.pressure;
-        finger_data.Size = transducer->currentCoordinates.width;
-        finger_data.Touch_Major = transducer->currentCoordinates.width;
-        finger_data.Touch_Minor = transducer->currentCoordinates.width;
+        if (transducer->supportsPressure) {
+            finger_data.Pressure = transducer->currentCoordinates.pressure;
+            finger_data.Size = transducer->currentCoordinates.width;
+            finger_data.Touch_Major = transducer->currentCoordinates.width;
+            finger_data.Touch_Minor = transducer->currentCoordinates.width;
+        } else {
+            if (new_touch_state[i] > 4) {
+                 finger_data.Size = 10;
+                 finger_data.Pressure = 10;
+                 finger_data.Touch_Minor = 32;
+                 finger_data.Touch_Major = 32;
+             } else if (new_touch_state[i] == 1) {
+                 newunknown = 0x20;
+                 finger_data.Size = 0;
+                 finger_data.Pressure = 0x0;
+                 finger_data.Touch_Minor = 0x0;
+                 finger_data.Touch_Major = 0x0;
+            } else if (new_touch_state[i] == 2) {
+                 newunknown = 0x70;
+                 finger_data.Size = 8;
+                 finger_data.Pressure = 10;
+                 finger_data.Touch_Minor = 16;
+                 finger_data.Touch_Major = 16;
+            } else if (new_touch_state[i] == 3) {
+                 finger_data.Size = 10;
+                 finger_data.Pressure = 10;
+                 finger_data.Touch_Minor = 32;
+                 finger_data.Touch_Major = 32;
+            } else if (new_touch_state[i] == 4) {
+                 finger_data.Size = 10;
+                 finger_data.Pressure = 10;
+                 finger_data.Touch_Minor = 32;
+                 finger_data.Touch_Major = 32;
+            }
+        }
 
         if (input_report.Button) {
             finger_data.Pressure = 120;

--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
@@ -102,8 +102,8 @@ void VoodooInputSimulatorDevice::constructReportGated(const VoodooInputEvent& mu
 
         MAGIC_TRACKPAD_INPUT_REPORT_FINGER& finger_data = input_report.FINGERS[i];
         
-        SInt16 x_min = MT2_MAX_X / 2;;
-        SInt16 y_min = MT2_MAX_Y / 2;;
+        SInt16 x_min = MT2_MAX_X / 2;
+        SInt16 y_min = MT2_MAX_Y / 2;
         
         IOFixed scaled_x = ((transducer->currentCoordinates.x * 1.0f) / engine->getLogicalMaxX()) * MT2_MAX_X;
         IOFixed scaled_y = ((transducer->currentCoordinates.y * 1.0f) / engine->getLogicalMaxY()) * MT2_MAX_Y;

--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
@@ -187,42 +187,16 @@ void VoodooInputSimulatorDevice::constructReportGated(const VoodooInputEvent& mu
         }
         
         finger_data.Priority = 4 - i;
-        finger_data.Size = 10;
-        finger_data.Touch_Minor = 20;
-        finger_data.Touch_Major = 20;
-        
+
         if (transducer->supportsPressure) {
             finger_data.Pressure = transducer->currentCoordinates.pressure;
             finger_data.Size = transducer->currentCoordinates.width;
             finger_data.Touch_Major = transducer->currentCoordinates.width;
             finger_data.Touch_Minor = transducer->currentCoordinates.width;
         } else {
-            if (touch_state[i] > 4) {
-                 finger_data.Size = 10;
-                 finger_data.Pressure = 10;
-                 finger_data.Touch_Minor = 32;
-                 finger_data.Touch_Major = 32;
-             } else if (touch_state[i] == 1) {
-                 finger_data.Size = 0;
-                 finger_data.Pressure = 0x0;
-                 finger_data.Touch_Minor = 0x0;
-                 finger_data.Touch_Major = 0x0;
-            } else if (touch_state[i] == 2) {
-                 finger_data.Size = 8;
-                 finger_data.Pressure = 10;
-                 finger_data.Touch_Minor = 16;
-                 finger_data.Touch_Major = 16;
-            } else if (touch_state[i] == 3) {
-                 finger_data.Size = 10;
-                 finger_data.Pressure = 10;
-                 finger_data.Touch_Minor = 32;
-                 finger_data.Touch_Major = 32;
-            } else if (touch_state[i] == 4) {
-                 finger_data.Size = 10;
-                 finger_data.Pressure = 10;
-                 finger_data.Touch_Minor = 32;
-                 finger_data.Touch_Major = 32;
-            }
+            finger_data.Size = 10;
+            finger_data.Touch_Minor = 20;
+            finger_data.Touch_Major = 20;
         }
         
         if (input_report.Button) {

--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.hpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.hpp
@@ -15,18 +15,46 @@
 #define EXPORT __attribute__((visibility("default")))
 #endif
 
-#define MT2_MAX_X 7612
-#define MT2_MAX_Y 5065
+#define MT2_MAX_X 8134
+#define MT2_MAX_Y 5206
 
+/* Finger Packet
++---+---+---+---+---+---+---+---+---+
+|   | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
++---+---+---+---+---+---+---+---+---+
+| 0 |           x: SInt13           |
++---+-----------+                   +
+| 1 |           |                   |
++---+           +-------------------+
+| 2 |           y: SInt13           |
++---+-----------+-----------+       +
+| 3 |   state   |  priority |       |
+|   |   UInt3   |   UInt3   |       |
++---+-----------+-----------+-------+
+| 4 |       touchMajor: UInt8       |
++---+-------------------------------+
+| 5 |       touchMinor: UInt8       |
++---+-------------------------------+
+| 6 |          size: UInt8          |
++---+-------------------------------+
+| 7 |        pressure: UInt8        |
++---+-----------+---+---------------+
+| 8 |   angle   | 0 |   fingerID    |
+|   |   UInt3   |   |     UInt4     |
++---+-----------+---+---------------+
+*/
 struct __attribute__((__packed__)) MAGIC_TRACKPAD_INPUT_REPORT_FINGER {
-    UInt8 AbsX;
-    UInt8 AbsXY;
-    UInt8 AbsY[2];
+    SInt16 X: 13;
+    SInt16 Y: 13;
+    UInt8 Priority: 3;
+    UInt8 State: 3;
     UInt8 Touch_Major;
     UInt8 Touch_Minor;
     UInt8 Size;
     UInt8 Pressure;
-    UInt8 Orientation_Origin;
+    UInt8 Identifier: 4;
+    UInt8 : 1;
+    UInt8 Angle: 3;
 };
 
 struct __attribute__((__packed__)) MAGIC_TRACKPAD_INPUT_REPORT {
@@ -89,9 +117,7 @@ private:
     VoodooInput* engine;
     AbsoluteTime start_timestamp;
     OSData* new_get_report_buffer = NULL;
-    UInt16 stashed_unknown[15];
-    UInt8 touch_state[15];
-    UInt8 new_touch_state[15];
+    UInt64 touch_state[15];
     int stylus_check = 0;
     IOWorkLoop* work_loop;
     IOCommandGate* command_gate;


### PR DESCRIPTION
I am currently working on adding VoodooInput support for VoodooI2C. VoodooI2C supports devices where the pressure or finger width is not necessarily reported. An easy fix is to re-add the pressure spoofing that was removed in commit https://github.com/acidanthera/VoodooInput/commit/e3e381d6329d84559ba2747c276a9e2bc91a478a#diff-9c0f831ad415aca9affec569d2f390eb.

I added a flag variable to switch between the new way of reporting and the old way of spoofing the pressure. VoodooPS2 will need to be updated to support this new way by adding the following:
```
transducer.supportsPressure = true;
```

after https://github.com/acidanthera/VoodooPS2/blob/master/VoodooPS2Trackpad/VoodooPS2SynapticsTouchPad.cpp#L1558. 

Additionally, this commit removes my name from the debug print statements.