### PR TITLE
Move parentProvider->close() into willTerminate()

### DIFF
--- a/VoodooInput/VoodooInput.cpp
+++ b/VoodooInput/VoodooInput.cpp
@@ -89,6 +89,14 @@ exit:
     return false;
 }
 
+bool VoodooInput::willTerminate(IOService* provider, IOOptionBits options) {
+    if (parentProvider->isOpen(this)) {
+        parentProvider->close(this);
+    }
+
+    return super::willTerminate(provider, options);
+}
+
 void VoodooInput::stop(IOService *provider) {
     if (simulator) {
         simulator->stop(this);
@@ -100,10 +108,6 @@ void VoodooInput::stop(IOService *provider) {
         actuator->stop(this);
         actuator->detach(this);
         OSSafeReleaseNULL(actuator);
-    }
-    
-    if (parentProvider->isOpen(this)) {
-        parentProvider->close(this);
     }
     
     super::stop(provider);

--- a/VoodooInput/VoodooInput.hpp
+++ b/VoodooInput/VoodooInput.hpp
@@ -34,6 +34,7 @@ class EXPORT VoodooInput : public IOService {
 public:
     bool start(IOService* provider) override;
     void stop(IOService* provider) override;
+    bool willTerminate(IOService* provider, IOOptionBits options) override;
     
     UInt8 getTransformKey();
 


### PR DESCRIPTION
The `parentProvider->close(this)` needs to be invoked before `stop()` or it will cause a deadlock when unloading. Currently, `parentProvider->close(this)` never gets invoked in `stop()` because VoodooI2C doesn't override the `handleIsOpen(...)` method.

Please refer to the original issue https://github.com/alexandred/VoodooI2C/issues/291 which regards the instance leak of VoodooInput.