### PR TITLE
The stylus check is a holdover from the previous native multitouch.  …

### DIFF
--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
@@ -44,10 +44,7 @@ void VoodooInputSimulatorDevice::constructReportGated(const VoodooInputEvent& mu
     input_report.Unused[4] = 0;
     
     const VoodooInputTransducer* transducer = &multitouch_event.transducers[0];
-    
-    if (transducer->isValid && transducer->type == VoodooInputTransducerType::STYLUS)
-        stylus_check = 1;
-    
+
     // physical button
     input_report.Button = transducer->isPhysicalButtonDown;
     
@@ -79,8 +76,8 @@ void VoodooInputSimulatorDevice::constructReportGated(const VoodooInputEvent& mu
     bool input_active = input_report.Button;
     bool is_error_input_active = false;
     
-    for (int i = 0; i < multitouch_event.contact_count + stylus_check; i++) {
-        const VoodooInputTransducer* transducer = &multitouch_event.transducers[i + stylus_check];
+    for (int i = 0; i < multitouch_event.contact_count; i++) {
+        const VoodooInputTransducer* transducer = &multitouch_event.transducers[i];
 
         if (!transducer || !transducer->isValid)
             continue;
@@ -312,9 +309,7 @@ bool VoodooInputSimulatorDevice::start(IOService* provider) {
     for (int i = 0; i < 15; i++) {
         touch_state[i] = 2;
     }
-    
-    stylus_check = 0;
-    
+        
     new_get_report_buffer = nullptr;
     
     ready_for_reports = true;

--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.hpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.hpp
@@ -125,7 +125,6 @@ private:
     AbsoluteTime start_timestamp;
     OSData* new_get_report_buffer = NULL;
     UInt8 touch_state[15];
-    int stylus_check = 0;
     IOWorkLoop* work_loop;
     IOCommandGate* command_gate;
     MAGIC_TRACKPAD_INPUT_REPORT input_report;


### PR DESCRIPTION
…For whatever reason it does not work in this context and I've created a pull request that fixes the associated issues here -- https://github.com/alexandred/VoodooI2C/pull/295  Tested and working on my device which was the baseline for touchscreen support in VoodooI2C.