### PR TITLE
Memory optimization

### DIFF
--- a/VoodooInput/VoodooInputSimulator/VoodooInputActuatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputActuatorDevice.cpp
@@ -17,6 +17,7 @@ IOReturn VoodooInputActuatorDevice::setReport(IOMemoryDescriptor* report, IOHIDR
 }
 
 IOReturn VoodooInputActuatorDevice::newReportDescriptor(IOMemoryDescriptor** descriptor) const {
+      IOLog("%s VoodooInputActuatorDevice report descriptor\n", getName());
     IOBufferMemoryDescriptor* report_descriptor_buffer = IOBufferMemoryDescriptor::inTaskWithOptions(kernel_task, 0, sizeof(actuator_report_descriptor));
     
     if (!report_descriptor_buffer) {
@@ -51,7 +52,7 @@ OSString* VoodooInputActuatorDevice::newProductString() const {
 }
 
 OSString* VoodooInputActuatorDevice::newSerialNumberString() const {
-    return OSString::withCString("VoodooI2C Magic Trackpad 2 Simulator");
+    return OSString::withCString("VoodooI2C Magic Trackpad 2 Actuator");
 }
 
 OSString* VoodooInputActuatorDevice::newTransportString() const {

--- a/VoodooInput/VoodooInputSimulator/VoodooInputActuatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputActuatorDevice.cpp
@@ -17,7 +17,6 @@ IOReturn VoodooInputActuatorDevice::setReport(IOMemoryDescriptor* report, IOHIDR
 }
 
 IOReturn VoodooInputActuatorDevice::newReportDescriptor(IOMemoryDescriptor** descriptor) const {
-      IOLog("%s VoodooInputActuatorDevice report descriptor\n", getName());
     IOBufferMemoryDescriptor* report_descriptor_buffer = IOBufferMemoryDescriptor::inTaskWithOptions(kernel_task, 0, sizeof(actuator_report_descriptor));
     
     if (!report_descriptor_buffer) {

--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
@@ -221,42 +221,40 @@ void VoodooInputSimulatorDevice::constructReportGated(const VoodooInputEvent& mu
     if (!is_error_input_active) {
         handleReport(memDesc, kIOHIDReportTypeInput);
     }
+    
+    if (!input_active) {
+        for (int i = 0; i < 15; i++) {
+            touch_state[i] = 2;
+        }
+
+        input_report.FINGERS[0].Size = 0x0;
+        input_report.FINGERS[0].Pressure = 0x0;
+        input_report.FINGERS[0].Touch_Major = 0x0;
+        input_report.FINGERS[0].Touch_Minor = 0x0;
+
+        milli_timestamp += 10;
+
+        input_report.timestamp_buffer[0] = (milli_timestamp << 0x3) | 0x4;
+        input_report.timestamp_buffer[1] = (milli_timestamp >> 0x5) & 0xFF;
+        input_report.timestamp_buffer[2] = (milli_timestamp >> 0xd) & 0xFF;
+        handleReport(memDesc, kIOHIDReportTypeInput);
+
+        input_report.FINGERS[0].Priority = 0x5;
+        input_report.FINGERS[0].State = 0x0;
+        handleReport(memDesc, kIOHIDReportTypeInput);
+
+        milli_timestamp += 10;
+        input_report.timestamp_buffer[0] = (milli_timestamp << 0x3) | 0x4;
+        input_report.timestamp_buffer[1] = (milli_timestamp >> 0x5) & 0xFF;
+        input_report.timestamp_buffer[2] = (milli_timestamp >> 0xd) & 0xFF;
+
+        handleReport(memDesc, kIOHIDReportTypeInput);
+
+    }
+
+
+
     input_report = {};
-    return;
-// The following code didn't have any impact in my unit.I don't think they are necessary.further testing needed.So,i'm just commenting them out.
-//    if (!input_active) {
-//        for (int i = 0; i < 15; i++) {
-//            touch_state[i] = 2;
-//        }
-//
-//        input_report.FINGERS[0].Size = 0x0;
-//        input_report.FINGERS[0].Pressure = 0x0;
-//        input_report.FINGERS[0].Touch_Major = 0x0;
-//        input_report.FINGERS[0].Touch_Minor = 0x0;
-//
-//        milli_timestamp += 10;
-//
-//        input_report.timestamp_buffer[0] = (milli_timestamp << 0x3) | 0x4;
-//        input_report.timestamp_buffer[1] = (milli_timestamp >> 0x5) & 0xFF;
-//        input_report.timestamp_buffer[2] = (milli_timestamp >> 0xd) & 0xFF;
-//        handleReport(memDesc, kIOHIDReportTypeInput);
-//
-//        input_report.FINGERS[0].Priority = 0x5;
-//        input_report.FINGERS[0].State = 0x0;
-//        handleReport(memDesc, kIOHIDReportTypeInput);
-//
-//        milli_timestamp += 10;
-//        input_report.timestamp_buffer[0] = (milli_timestamp << 0x3) | 0x4;
-//        input_report.timestamp_buffer[1] = (milli_timestamp >> 0x5) & 0xFF;
-//        input_report.timestamp_buffer[2] = (milli_timestamp >> 0xd) & 0xFF;
-//
-//        handleReport(memDesc, kIOHIDReportTypeInput);
-//
-//    }
-//
-//
-//
-//    input_report = {};
 
 }
 

--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
@@ -256,6 +256,10 @@ bool VoodooInputSimulatorDevice::start(IOService* provider) {
     ready_for_reports = false;
 
     kernel_buffer = IOMemoryDescriptor::withAddressRange((mach_vm_address_t)&input_report, sizeof(input_report), kIODirectionNone, kernel_task);
+    if (!kernel_buffer) {
+        IOLog("%s Could not allocate kernel_buffer\n", getName());
+        return false;
+    }
     kernel_buffer->prepare();
 
     clock_get_uptime(&start_timestamp);

--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
@@ -327,6 +327,7 @@ void VoodooInputSimulatorDevice::releaseResources() {
     
     OSSafeReleaseNULL(new_get_report_buffer);
     
+    kernel_buffer->complete();
     OSSafeReleaseNULL(kernel_buffer);
 
 }

--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
@@ -217,68 +217,53 @@ void VoodooInputSimulatorDevice::constructReportGated(const VoodooInputEvent& mu
         input_report.TouchActive = 0x3;
     else
         input_report.TouchActive = 0x2;
-//    IOBufferMemoryDescriptor* buffer_report;
-//    int total_report_len = (9 * multitouch_event.contact_count) + 12;
-//    buffer_report = IOBufferMemoryDescriptor::inTaskWithOptions(kernel_task, 0, total_report_len);
-//    IOLog("%s VoodooInputSimulatorDevice IOBufferMemoryDescriptor 1, len: %d , sizeof: %lu  \n", getName(),total_report_len,sizeof(input_report));
+    
     if (!is_error_input_active) {
-//        buffer_report->writeBytes(0, &input_report, total_report_len);
         handleReport(memDesc, kIOHIDReportTypeInput);
-        
     }
     input_report = {};
     return;
-    //buffer_report->release();
-    //buffer_report = NULL;
-    
+// The following code didn't have any impact in my unit.I don't think they are necessary.further testing needed.So,i'm just commenting them out.
+//    if (!input_active) {
+//        for (int i = 0; i < 15; i++) {
+//            touch_state[i] = 2;
+//        }
+//
+//        input_report.FINGERS[0].Size = 0x0;
+//        input_report.FINGERS[0].Pressure = 0x0;
+//        input_report.FINGERS[0].Touch_Major = 0x0;
+//        input_report.FINGERS[0].Touch_Minor = 0x0;
+//
+//        milli_timestamp += 10;
+//
+//        input_report.timestamp_buffer[0] = (milli_timestamp << 0x3) | 0x4;
+//        input_report.timestamp_buffer[1] = (milli_timestamp >> 0x5) & 0xFF;
+//        input_report.timestamp_buffer[2] = (milli_timestamp >> 0xd) & 0xFF;
+//        handleReport(memDesc, kIOHIDReportTypeInput);
+//
+//        input_report.FINGERS[0].Priority = 0x5;
+//        input_report.FINGERS[0].State = 0x0;
+//        handleReport(memDesc, kIOHIDReportTypeInput);
+//
+//        milli_timestamp += 10;
+//        input_report.timestamp_buffer[0] = (milli_timestamp << 0x3) | 0x4;
+//        input_report.timestamp_buffer[1] = (milli_timestamp >> 0x5) & 0xFF;
+//        input_report.timestamp_buffer[2] = (milli_timestamp >> 0xd) & 0xFF;
+//
+//        handleReport(memDesc, kIOHIDReportTypeInput);
+//
+//    }
+//
+//
+//
+//    input_report = {};
 
-    
-    if (!input_active) {
-        for (int i = 0; i < 15; i++) {
-            touch_state[i] = 2;
-        }
-        
-        input_report.FINGERS[0].Size = 0x0;
-        input_report.FINGERS[0].Pressure = 0x0;
-        input_report.FINGERS[0].Touch_Major = 0x0;
-        input_report.FINGERS[0].Touch_Minor = 0x0;
-
-        milli_timestamp += 10;
-        
-        input_report.timestamp_buffer[0] = (milli_timestamp << 0x3) | 0x4;
-        input_report.timestamp_buffer[1] = (milli_timestamp >> 0x5) & 0xFF;
-        input_report.timestamp_buffer[2] = (milli_timestamp >> 0xd) & 0xFF;
-        handleReport(memDesc, kIOHIDReportTypeInput);
-        //IOLog("%s VoodooInputSimulatorDevice IOBufferMemoryDescriptor 2. Len: %d ,Prio: %d, State: %d \n", getName(),total_report_len,input_report.FINGERS[0].Priority,input_report.FINGERS[0].State);
-        
-        
-        input_report.FINGERS[0].Priority = 0x5;
-        input_report.FINGERS[0].State = 0x0;
-        handleReport(memDesc, kIOHIDReportTypeInput);
-        //IOLog("%s VoodooInputSimulatorDevice IOBufferMemoryDescriptor 3. Len: %d ,Prio: %d, State: %d \n", getName(),total_report_len,input_report.FINGERS[0].Priority,input_report.FINGERS[0].State);
-        
-        milli_timestamp += 10;
-        
-        input_report.timestamp_buffer[0] = (milli_timestamp << 0x3) | 0x4;
-        input_report.timestamp_buffer[1] = (milli_timestamp >> 0x5) & 0xFF;
-        input_report.timestamp_buffer[2] = (milli_timestamp >> 0xd) & 0xFF;
-
-        handleReport(memDesc, kIOHIDReportTypeInput);
-        
-        
-        //IOLog("%s VoodooInputSimulatorDevice IOBufferMemoryDescriptor 3.\n", getName());
-    }
-    
-    
-    
-    input_report = {};
-    //memDesc->complete();
 }
 
 bool VoodooInputSimulatorDevice::start(IOService* provider) {
     if (!super::start(provider))
         return false;
-    memDesc = IOMemoryDescriptor::withAddressRange((mach_vm_address_t)&input_report, 39, kIODirectionNone, kernel_task);
+    memDesc = IOMemoryDescriptor::withAddressRange((mach_vm_address_t)&input_report, 39, kIODirectionNone, kernel_task); // hardcoded to 39 bytes because this is the maximum lenght of the size of input_report i've got so far.Needs further testing.If the size of the report is more than the allocated memory then Trackpad will behave abnormal.
     memDesc->prepare();
     ready_for_reports = false;
     
@@ -437,7 +422,6 @@ IOReturn VoodooInputSimulatorDevice::setReport(IOMemoryDescriptor* report, IOHID
 
 IOReturn VoodooInputSimulatorDevice::getReport(IOMemoryDescriptor* report, IOHIDReportType reportType, IOOptionBits options) {
     IOLog("%s VoodooInputSimulatorDevice getReport\n", getName());
-    //IOSleep(1000);
     UInt32 report_id = options & 0xFF;
     Boolean getReportedAllocated = true;
     
@@ -583,7 +567,7 @@ OSString* VoodooInputSimulatorDevice::newProductString() const {
 }
 
 OSString* VoodooInputSimulatorDevice::newSerialNumberString() const {
-    return OSString::withCString("Voodoo Magic Trackpad 2 SimulatorX");
+    return OSString::withCString("Voodoo Magic Trackpad 2 Simulator");
 }
 
 OSString* VoodooInputSimulatorDevice::newTransportString() const {

--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.hpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.hpp
@@ -81,6 +81,7 @@ class EXPORT VoodooInputSimulatorDevice : public IOHIDDevice {
     OSDeclareDefaultStructors(VoodooInputSimulatorDevice);
     
 public:
+    IOMemoryDescriptor * memDesc;
     void constructReport(const VoodooInputEvent& multitouch_event);
 
     IOReturn setReport(IOMemoryDescriptor* report, IOHIDReportType reportType, IOOptionBits options) override;

--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.hpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.hpp
@@ -81,24 +81,22 @@ class EXPORT VoodooInputSimulatorDevice : public IOHIDDevice {
     OSDeclareDefaultStructors(VoodooInputSimulatorDevice);
     
 public:
-    IOMemoryDescriptor * memDesc;
+    IOMemoryDescriptor * kernel_buffer = nullptr;
+
     void constructReport(const VoodooInputEvent& multitouch_event);
 
     IOReturn setReport(IOMemoryDescriptor* report, IOHIDReportType reportType, IOOptionBits options) override;
 
     IOReturn getReport(IOMemoryDescriptor* report, IOHIDReportType reportType, IOOptionBits options) override;
     IOReturn newReportDescriptor(IOMemoryDescriptor** descriptor) const override;
+
     OSNumber* newVendorIDNumber() const override;
-    
     
     OSNumber* newProductIDNumber() const override;
     
-    
     OSNumber* newVersionNumber() const override;
-    
-    
+
     OSString* newTransportString() const override;
-    
     
     OSString* newManufacturerString() const override;
     

--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.hpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.hpp
@@ -81,7 +81,7 @@ class EXPORT VoodooInputSimulatorDevice : public IOHIDDevice {
     OSDeclareDefaultStructors(VoodooInputSimulatorDevice);
     
 public:
-    IOMemoryDescriptor * kernel_buffer = nullptr;
+    IOBufferMemoryDescriptor* input_report_buffer = nullptr;
 
     void constructReport(const VoodooInputEvent& multitouch_event);
 
@@ -126,7 +126,7 @@ private:
     UInt8 touch_state[15];
     IOWorkLoop* work_loop;
     IOCommandGate* command_gate;
-    MAGIC_TRACKPAD_INPUT_REPORT input_report;
+    MAGIC_TRACKPAD_INPUT_REPORT *input_report = nullptr;
 
     void constructReportGated(const VoodooInputEvent& multitouch_event);
 };


### PR DESCRIPTION
Use same buffer to share memory with kernel.This removes some unnecessary overheads of memory copying back and forth.~Also,i've used **39** Bytes in **IOMemoryDescriptor::withAddressRange()** because in my  test this is the maximum lenght of the input_report i get.I've tested with precision Trackpad.The value can be adjusted if needed.~