### PR TITLE
Add message to update properties

### DIFF
--- a/VoodooInput/VoodooInput.hpp
+++ b/VoodooInput/VoodooInput.hpp
@@ -43,7 +43,9 @@ public:
 
     UInt32 getLogicalMaxX();
     UInt32 getLogicalMaxY();
-    
+
+    bool updateProperties();
+
     IOReturn message(UInt32 type, IOService *provider, void *argument) override;
 };
 

--- a/VoodooInput/VoodooInputMultitouch/VoodooInputMessages.h
+++ b/VoodooInput/VoodooInputMultitouch/VoodooInputMessages.h
@@ -19,6 +19,7 @@
 #define VOODOO_INPUT_MAX_TRANSDUCERS 10
 #define kIOMessageVoodooInputMessage 12345
 #define kIOMessageVoodooInputUpdateDimensionsMessage 12346
+#define kIOMessageVoodooInputUpdatePropertiesNotification 12347
 
 #define kVoodooInputTransducerFingerType 1
 #define kVoodooInputTransducerStylusType 2


### PR DESCRIPTION
- Lookup properties through parent entries recursively.
- Add a type of message to update properties. Fix https://github.com/VoodooI2C/VoodooI2C/issues/338

Those changes won't break VoodooInput compatibility.