### PR TITLE
Eliminate leftover scaling of physical dimensions by x10

### DIFF
--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
@@ -479,8 +479,8 @@ IOReturn VoodooInputSimulatorDevice::getReport(IOMemoryDescriptor* report, IOHID
         // Sensor Surface Width = 0x3cf0 (0xf0, 0x3c) = 15.600 cm
         // Sensor Surface Height = 0x2b20 (0x20, 0x2b) = 11.040 cm
         
-        uint32_t rawWidth = engine->getPhysicalMaxX() * 10;
-        uint32_t rawHeight = engine->getPhysicalMaxY() * 10;
+        uint32_t rawWidth = engine->getPhysicalMaxX();
+        uint32_t rawHeight = engine->getPhysicalMaxY();
         
         uint8_t rawWidthLower = rawWidth & 0xff;
         uint8_t rawWidthHigher = (rawWidth >> 8) & 0xff;


### PR DESCRIPTION
When the MT2 simulator was integrated in VoodooI2C we apparently reported the dimensions in 0.1 mm units, later scaling those by `x10`.
VoodooInput gets them in 0.01 mm units hence no scaling is necessary.

Extra scaling can make the reported 16-bit values overflow and cause funky input (See VoodooI2C/VoodooI2C#428 for example of broken scaling, on the VoodooI2CHID side though).
While it doesn't seem to cause anything like that now, we probably want to eliminate that leftover scaling.