### PR TITLE
Update touch state definition

### DIFF
--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.hpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.hpp
@@ -25,6 +25,18 @@
 #define MT2_MAX_X 8134
 #define MT2_MAX_Y 5206
 
+/* State bits reference: linux/drivers/hid/hid-magicmouse.c#L58-L63 */
+#define MT2_TOUCH_STATE_BIT_TRANSITION (0x1)
+#define MT2_TOUCH_STATE_BIT_NEAR (0x1 << 1)
+#define MT2_TOUCH_STATE_BIT_CONTACT (0x1 << 2)
+
+enum TouchStates {
+    kTouchStateInactive = 0x0,
+    kTouchStateStart = MT2_TOUCH_STATE_BIT_NEAR | MT2_TOUCH_STATE_BIT_TRANSITION,
+    kTouchStateActive = MT2_TOUCH_STATE_BIT_CONTACT,
+    kTouchStateStop = MT2_TOUCH_STATE_BIT_CONTACT | MT2_TOUCH_STATE_BIT_NEAR | MT2_TOUCH_STATE_BIT_TRANSITION
+};
+
 /* Finger Packet
 +---+---+---+---+---+---+---+---+---+
 |   | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
@@ -113,7 +125,7 @@ private:
     VoodooInput* engine {nullptr};
     AbsoluteTime start_timestamp {};
     OSData* new_get_report_buffer {nullptr};
-    UInt8 touch_state[15] {};
+    bool touch_active[15] {false};
     IOWorkLoop* work_loop {nullptr};
     IOCommandGate* command_gate {nullptr};
     IOBufferMemoryDescriptor* input_report_buffer {nullptr};


### PR DESCRIPTION
Update the definition of the touch state field in the input report to clarify the logic of state transition and also reduce the magic numbers. Some of this part refers to the Linux driver for Magic Mouse.