### PR TITLE
Implement TrackpointDevice::willTerminate to prevent crashes with USB devices

### DIFF
--- a/VoodooInput/Trackpoint/TrackpointDevice.cpp
+++ b/VoodooInput/Trackpoint/TrackpointDevice.cpp
@@ -152,3 +152,7 @@ void TrackpointDevice::updateRelativePointer(int dx, int dy, int buttons, uint64
 void TrackpointDevice::updateScrollwheel(short deltaAxis1, short deltaAxis2, short deltaAxis3, uint64_t timestamp) {
     dispatchScrollWheelEvent(deltaAxis1, deltaAxis2, deltaAxis3, timestamp);
 }
+
+bool TrackpointDevice::willTerminate(IOService* provider, IOOptionBits options) {
+    return  super::willTerminate(provider, options);
+}

--- a/VoodooInput/Trackpoint/TrackpointDevice.hpp
+++ b/VoodooInput/Trackpoint/TrackpointDevice.hpp
@@ -46,6 +46,7 @@ protected:
 public:
     bool start(IOService* provider) override;
     void stop(IOService* provider) override;
+    bool willTerminate(IOService* provider, IOOptionBits options) override;
     
     virtual UInt32 deviceType() override;
     virtual UInt32 interfaceID() override;


### PR DESCRIPTION
This PR will fix panics upon shutdown when VoodooInput is attached to a USB device on Ventura/macOS 13+. 

Primarily, this fixes https://github.com/VoodooI2C/VoodooI2C/issues/507 where VoodooI2CHID is attached to a USB based device and panics on shutdown due to the missing `willTerminate` method on VoodooInput's `TrackpointDevice`.

For further context,  I suspect this issue was caused by Apple adding a new virtual method to `IOHIDFamily` which can be see in this [Git diff](https://github.com/apple-oss-distributions/IOHIDFamily/commit/1ca71a23b43de09cb3968515586840eacf817445#diff-199f69200ddd9c810f0c1b873e6f46528f33858efc9c94baa6481e1d4a4c1701R340) and this [offending line](https://github.com/apple-oss-distributions/IOHIDFamily/blob/main/IOHIDFamily/IOHIDDevice.h#L340). 

Furthemore, I am not sure why this fixes the crash on my test device. I suspect there are further changes on the IOKit's USB stack that I am not aware of and I was very lucky to stumble upon this fix. 