### PR TITLE
Add palm/invalid finger type

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 VoodooInput Changelog
 =====================
+#### v1.1.4
+- Added palm/invalid finger type
+
 #### v1.1.3
 - Added trackpoint logic improvements by @1Revenger1
 - Seperated X and Y axis

--- a/VoodooInput/VoodooInputMultitouch/VoodooInputTransducer.h
+++ b/VoodooInput/VoodooInputMultitouch/VoodooInputTransducer.h
@@ -17,7 +17,8 @@ enum MT2FingerType {
     kMT2FingerTypeMiddleFinger,
     kMT2FingerTypeRingFinger,
     kMT2FingerTypeLittleFinger,
-    kMT2FingerTypeCount
+    kMT2FingerTypePalm,
+    kMT2FingerTypeCount = kMT2FingerTypePalm
 };
 
 enum VoodooInputTransducerType {


### PR DESCRIPTION
This finger type can be sent to macOS when we believe that a finger is now invalid/too large. It causes macOS to ignore the finger while preventing tapping and other odd behavior.

I've had pretty good luck using this with the [I2C ELAN](https://github.com/VoodooI2C/VoodooI2CELAN/pull/21) driver, and this also maps well with the "Confidence" bit found in the HID standard as well.

Drivers in the future should probably start forwarding all finger data to macOS even if the touch is not valid. This means that packets should be sent during quiet times.