### PR TITLE
Spoof newer Touchpad for Sequoia

### DIFF
--- a/VoodooInput.xcodeproj/project.pbxproj
+++ b/VoodooInput.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		7BBAB21922E3AD0E00B2941A /* VoodooInputActuatorDevice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BBAB21322E3AD0D00B2941A /* VoodooInputActuatorDevice.cpp */; };
 		7BBAB21B22E3AD0E00B2941A /* VoodooInputActuatorDevice.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7BBAB21522E3AD0E00B2941A /* VoodooInputActuatorDevice.hpp */; };
 		CE8DA19D2518354A008C44E8 /* libkmod.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE8DA19C2518354A008C44E8 /* libkmod.a */; };
+		EEC13CEB2C1DFD300080F2D1 /* VoodooInputIDs.hpp in Headers */ = {isa = PBXBuildFile; fileRef = EEC13CEA2C1DFD270080F2D1 /* VoodooInputIDs.hpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -37,6 +38,7 @@
 		CEFB081B239658DB00215B0B /* Changelog.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Changelog.md; sourceTree = SOURCE_ROOT; };
 		CEFB081D2397003600215B0B /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
 		CEFB081E2397003600215B0B /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = SOURCE_ROOT; };
+		EEC13CEA2C1DFD270080F2D1 /* VoodooInputIDs.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = VoodooInputIDs.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,6 +89,7 @@
 				7BBAB20F22E3AC7E00B2941A /* VoodooInputSimulator */,
 				7BBAB1FC22E3A2F800B2941A /* VoodooInput.hpp */,
 				7BBAB1FE22E3A2F800B2941A /* VoodooInput.cpp */,
+				EEC13CEA2C1DFD270080F2D1 /* VoodooInputIDs.hpp */,
 				7BBAB20022E3A2F800B2941A /* Info.plist */,
 			);
 			path = VoodooInput;
@@ -144,6 +147,7 @@
 				358914F425798FA5007A0B58 /* TrackpointDevice.hpp in Headers */,
 				7BBAB21B22E3AD0E00B2941A /* VoodooInputActuatorDevice.hpp in Headers */,
 				7BBAB1FD22E3A2F800B2941A /* VoodooInput.hpp in Headers */,
+				EEC13CEB2C1DFD300080F2D1 /* VoodooInputIDs.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VoodooInput/VoodooInput.cpp
+++ b/VoodooInput/VoodooInput.cpp
@@ -212,7 +212,7 @@ IOReturn VoodooInput::message(UInt32 type, IOService *provider, void *argument) 
 int VoodooInputGetProductId() {
     if (version_major >= kVoodooInputVersionSequoia) {
         return kVoodooInputProductMacbookAir10_1;
-    } else {
-        return kVoodooInputProductMacbook8_1;
     }
+    
+    return kVoodooInputProductMacbook8_1;
 }

--- a/VoodooInput/VoodooInput.cpp
+++ b/VoodooInput/VoodooInput.cpp
@@ -210,7 +210,7 @@ IOReturn VoodooInput::message(UInt32 type, IOService *provider, void *argument) 
 }
 
 int VoodooInputGetProductId() {
-    if (version_major >= kVoodooInputVersionSequoia) {
+    if (version_major >= kVoodooInputVersionMonterey) {
         return kVoodooInputProductMacbookAir10_1;
     }
     

--- a/VoodooInput/VoodooInput.cpp
+++ b/VoodooInput/VoodooInput.cpp
@@ -7,10 +7,13 @@
 //
 
 #include "VoodooInput.hpp"
+#include "VoodooInputIDs.hpp"
 #include "VoodooInputMultitouch/VoodooInputMessages.h"
 #include "VoodooInputSimulator/VoodooInputActuatorDevice.hpp"
 #include "VoodooInputSimulator/VoodooInputSimulatorDevice.hpp"
 #include "Trackpoint/TrackpointDevice.hpp"
+
+#include "libkern/version.h"
 
 #define super IOService
 OSDefineMetaClassAndStructors(VoodooInput, IOService);
@@ -204,4 +207,12 @@ IOReturn VoodooInput::message(UInt32 type, IOService *provider, void *argument) 
     }
 
     return super::message(type, provider, argument);
+}
+
+int VoodooInputGetProductId() {
+    if (version_major >= kVoodooInputVersionSequoia) {
+        return kVoodooInputProductMacbookAir10_1;
+    } else {
+        return kVoodooInputProductMacbook8_1;
+    }
 }

--- a/VoodooInput/VoodooInputIDs.hpp
+++ b/VoodooInput/VoodooInputIDs.hpp
@@ -10,11 +10,11 @@
 
 // macOS 10.10-14
 constexpr int kVoodooInputProductMacbook8_1 = 0x272;
-// macOS 15+
+// macOS 12+
 constexpr int kVoodooInputProductMacbookAir10_1 = 0x281;
 constexpr int kVoodooInputVendorApple = 0x5ac;
 
-constexpr int kVoodooInputVersionSequoia = 24;
+constexpr int kVoodooInputVersionMonterey = 21;
 
 int VoodooInputGetProductId();
 

--- a/VoodooInput/VoodooInputIDs.hpp
+++ b/VoodooInput/VoodooInputIDs.hpp
@@ -1,0 +1,21 @@
+//
+//  VoodooInputIDs.hpp
+//
+//  Created by Avery Black on 6/15/24.
+//  Copyright © 2024 Kishor Prins. All rights reserved.
+//
+
+#ifndef VOODOO_INPUT_IDS_HPP
+#define VOODOO_INPUT_IDS_HPP
+
+// macOS 10.10-14
+constexpr int kVoodooInputProductMacbook8_1 = 0x272;
+// macOS 15+
+constexpr int kVoodooInputProductMacbookAir10_1 = 0x281;
+constexpr int kVoodooInputVendorApple = 0x5ac;
+
+constexpr int kVoodooInputVersionSequoia = 24;
+
+int VoodooInputGetProductId();
+
+#endif // VOODOO_INPUT_IDS_HPP

--- a/VoodooInput/VoodooInputSimulator/VoodooInputActuatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputActuatorDevice.cpp
@@ -6,7 +6,7 @@
 //
 
 #include "VoodooInputActuatorDevice.hpp"
-#include <libkern/version.h>
+#include "VoodooInputIDs.hpp"
 
 #define super IOHIDDevice
 OSDefineMetaClassAndStructors(VoodooInputActuatorDevice, IOHIDDevice);
@@ -44,8 +44,7 @@ OSNumber* VoodooInputActuatorDevice::newPrimaryUsagePageNumber() const {
 }
 
 OSNumber* VoodooInputActuatorDevice::newProductIDNumber() const {
-    constexpr int Sequoia = 24;
-    return OSNumber::withNumber(version_major >= Sequoia ? 0x281 : 0x272, 32);
+    return OSNumber::withNumber(VoodooInputGetProductId(), 32);
 }
 
 OSString* VoodooInputActuatorDevice::newProductString() const {
@@ -61,7 +60,7 @@ OSString* VoodooInputActuatorDevice::newTransportString() const {
 }
 
 OSNumber* VoodooInputActuatorDevice::newVendorIDNumber() const {
-    return OSNumber::withNumber(0x5ac, 16);
+    return OSNumber::withNumber(kVoodooInputVendorApple, 16);
 }
 
 OSNumber* VoodooInputActuatorDevice::newLocationIDNumber() const {

--- a/VoodooInput/VoodooInputSimulator/VoodooInputActuatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputActuatorDevice.cpp
@@ -43,7 +43,7 @@ OSNumber* VoodooInputActuatorDevice::newPrimaryUsagePageNumber() const {
 }
 
 OSNumber* VoodooInputActuatorDevice::newProductIDNumber() const {
-    return OSNumber::withNumber(0x272, 32);
+    return OSNumber::withNumber(0x265, 32);
 }
 
 OSString* VoodooInputActuatorDevice::newProductString() const {

--- a/VoodooInput/VoodooInputSimulator/VoodooInputActuatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputActuatorDevice.cpp
@@ -6,6 +6,7 @@
 //
 
 #include "VoodooInputActuatorDevice.hpp"
+#include <libkern/version.h>
 
 #define super IOHIDDevice
 OSDefineMetaClassAndStructors(VoodooInputActuatorDevice, IOHIDDevice);
@@ -43,7 +44,8 @@ OSNumber* VoodooInputActuatorDevice::newPrimaryUsagePageNumber() const {
 }
 
 OSNumber* VoodooInputActuatorDevice::newProductIDNumber() const {
-    return OSNumber::withNumber(0x265, 32);
+    constexpr int Sequoia = 24;
+    return OSNumber::withNumber(version_major >= Sequoia ? 0x281 : 0x272, 32);
 }
 
 OSString* VoodooInputActuatorDevice::newProductString() const {

--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
@@ -501,7 +501,7 @@ OSNumber* VoodooInputSimulatorDevice::newPrimaryUsagePageNumber() const {
 }
 
 OSNumber* VoodooInputSimulatorDevice::newProductIDNumber() const {
-    return OSNumber::withNumber(0x272, 32);
+    return OSNumber::withNumber(0x265, 32);
 }
 
 OSString* VoodooInputSimulatorDevice::newProductString() const {

--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
@@ -11,6 +11,7 @@
 
 #include <IOKit/IOWorkLoop.h>
 #include <IOKit/IOCommandGate.h>
+#include <libkern/version.h>
 
 #define super IOHIDDevice
 OSDefineMetaClassAndStructors(VoodooInputSimulatorDevice, IOHIDDevice);
@@ -501,7 +502,8 @@ OSNumber* VoodooInputSimulatorDevice::newPrimaryUsagePageNumber() const {
 }
 
 OSNumber* VoodooInputSimulatorDevice::newProductIDNumber() const {
-    return OSNumber::withNumber(0x265, 32);
+    constexpr int Sequoia = 24;
+    return OSNumber::withNumber(version_major >= Sequoia ? 0x281 : 0x272, 32);
 }
 
 OSString* VoodooInputSimulatorDevice::newProductString() const {

--- a/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
+++ b/VoodooInput/VoodooInputSimulator/VoodooInputSimulatorDevice.cpp
@@ -8,10 +8,10 @@
 #include "VoodooInput.hpp"
 #include "VoodooInputSimulatorDevice.hpp"
 #include "../VoodooInputMultitouch/MultitouchHelpers.h"
+#include "VoodooInputIDs.hpp"
 
 #include <IOKit/IOWorkLoop.h>
 #include <IOKit/IOCommandGate.h>
-#include <libkern/version.h>
 
 #define super IOHIDDevice
 OSDefineMetaClassAndStructors(VoodooInputSimulatorDevice, IOHIDDevice);
@@ -502,8 +502,7 @@ OSNumber* VoodooInputSimulatorDevice::newPrimaryUsagePageNumber() const {
 }
 
 OSNumber* VoodooInputSimulatorDevice::newProductIDNumber() const {
-    constexpr int Sequoia = 24;
-    return OSNumber::withNumber(version_major >= Sequoia ? 0x281 : 0x272, 32);
+    return OSNumber::withNumber(VoodooInputGetProductId(), 32);
 }
 
 OSString* VoodooInputSimulatorDevice::newProductString() const {
@@ -519,7 +518,7 @@ OSString* VoodooInputSimulatorDevice::newTransportString() const {
 }
 
 OSNumber* VoodooInputSimulatorDevice::newVendorIDNumber() const {
-    return OSNumber::withNumber(0x5ac, 16);
+    return OSNumber::withNumber(kVoodooInputVendorApple, 16);
 }
 
 OSNumber* VoodooInputSimulatorDevice::newLocationIDNumber() const {


### PR DESCRIPTION
Spoofs a newer touchpad. macOS Sequoia dropped the IOKit personalities for the older SPI touchpads, including the one used by VoodooInput.